### PR TITLE
partially reverse last rtp commit

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -556,7 +556,7 @@ int streams_add()
 	ss->useragent[0] = 0;
 	ss->len = 0;
 	ss->st_sock = -1;
-	ss->seq = rand(); // set the sequence to 0 for testing purposes - it should be random
+//	ss->seq = rand() & 0x7FFF; // set the sequence to 0 for testing purposes - it should be random 15bit
 	ss->ssrc = random();
 	ss->timeout = opts.timeout_sec;
 	ss->wtime = ss->rtcp_wtime = getTick();


### PR DESCRIPTION
with the random start VDR spew out a lot of RTP errors if not start at 0
it need more investigation where the issue comes from and starting random is only a security feature