### PR TITLE
Coverity fix in pmt.c

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1501,7 +1501,8 @@ int process_pat(int filter, unsigned char *b, int len, void *opaque) {
             else
                 LOG("could not add PMT pid %d sid %d (%X) for processing", pid,
                     sid, sid);
-            seen_pmts[pmt_id] = 1;
+	    if(pmt_id > 0)
+            	seen_pmts[pmt_id] = 1;
         }
     }
 


### PR DESCRIPTION
Negative array index write
A memory location at a negative offset from the beginning of the array will be written, likely causing a crash later.
In process_pat: Negative value used to index an array in a write operation (CWE-129)